### PR TITLE
Add CSRF protection to admin forms

### DIFF
--- a/.cursor/rules/the-virtual-armory-project-rules.mdc
+++ b/.cursor/rules/the-virtual-armory-project-rules.mdc
@@ -1,0 +1,31 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+
+# Your rule content
+
+- @internal/testutils/README.md  is our current location where key test information is for our project. 
+
+- We are Tailwind/HTMX.
+
+- We build the site with make build -- see the Makefile.
+
+- We run the site with make run.
+
+- The main main.go is @cmd/api/main.go
+
+- The data structs for views is generally in @cmd/views/data
+
+- This site is golang.
+
+- This site uses Gin/Gonic.
+
+- This site also uses Gin Sessions.
+
+- This site uses GoGuardian for auth.
+
+- This site uses Casbin for RBAC, though presently limited in scope to /admin routes.
+
+- CSRF is a custom middleware specific to our site.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,101 @@
-# Project github.com/hail2skins/armory
+# The Virtual Armory
 
-One Paragraph of project description goes here
+A modern web application for firearms enthusiasts to catalog and manage their collection. The Virtual Armory provides a secure platform for users to document, organize, and track firearms with detailed specifications and features.
+
+## Features
+
+- Secure user authentication and authorization
+- RBAC (Role-Based Access Control) for admin functionality
+- Manufacturer, caliber, and weapon type management
+- Subscription-based model with multiple tiers (free, monthly, yearly, lifetime)
+- Promotion management for special subscription offers
+- Stripe integration for payment processing
+- CSRF protection across all forms
+- Responsive design with Tailwind CSS
+
+## Technology Stack
+
+- **Backend**: Go with Gin/Gonic web framework
+- **Frontend**: Tailwind CSS and HTMX
+- **Authentication**: GoGuardian
+- **Access Control**: Casbin for RBAC
+- **Payment Processing**: Stripe
+- **Template Engine**: Templ
+- **Database**: PostgreSQL
+- **Security**: Custom CSRF middleware
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+These instructions will help you set up a local development environment for The Virtual Armory.
 
-## MakeFile
+### Prerequisites
 
-Run build make command with tests
+- Go 1.20 or later
+- Docker (for PostgreSQL container)
+- Node.js (for Tailwind CSS)
+
+### Setup
+
+1. Clone the repository
 ```bash
-make all
+git clone https://github.com/hail2skins/armory.git
+cd armory
 ```
 
-Build the application
-```bash
-make build
-```
-
-Run the application
-```bash
-make run
-```
-Create DB container
+2. Start the database container
 ```bash
 make docker-run
 ```
 
-Shutdown DB Container
+3. Build the application
+```bash
+make build
+```
+
+4. Run the application
+```bash
+make run
+```
+
+The application should now be running at http://localhost:8080
+
+### Development Workflow
+
+Live reload the application during development:
+```bash
+make watch
+```
+
+## Makefile Commands
+
+Run build with tests:
+```bash
+make all
+```
+
+Build the application:
+```bash
+make build
+```
+
+Run the application:
+```bash
+make run
+```
+
+Create database container:
+```bash
+make docker-run
+```
+
+Shutdown database container:
 ```bash
 make docker-down
 ```
 
-DB Integrations Test:
+Run integration tests:
 ```bash
 make itest
-```
-
-Live reload the application:
-```bash
-make watch
 ```
 
 Run the test suite:
@@ -51,3 +107,20 @@ Clean up binary from the last build:
 ```bash
 make clean
 ```
+
+## Project Structure
+
+- `/cmd`: Application entry points
+  - `/api`: API server
+  - `/web`: Web server and templates
+- `/internal`: Internal packages
+  - `/controller`: HTTP handlers
+  - `/middleware`: Custom middleware (CSRF, auth)
+  - `/models`: Database models
+  - `/services`: Business logic
+- `/tests`: Test suites and utilities
+- `/cmd/web/views`: Templ templates
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/cmd/web/views/admin/caliber/edit.templ
+++ b/cmd/web/views/admin/caliber/edit.templ
@@ -39,6 +39,7 @@ templ Edit(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/calibers/`+strconv.Itoa(int(data.Caliber.ID))+`" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="caliber">
 						Caliber

--- a/cmd/web/views/admin/caliber/index.templ
+++ b/cmd/web/views/admin/caliber/index.templ
@@ -96,6 +96,7 @@ templ Index(data *data.AdminData) {
 						<a href="/admin/calibers/`+strconv.Itoa(int(c.ID))+`" class="text-brass-600 hover:text-brass-700 mr-3">View</a>
 						<a href="/admin/calibers/`+strconv.Itoa(int(c.ID))+`/edit" class="text-brass-600 hover:text-brass-700 mr-3">Edit</a>
 						<form action="/admin/calibers/`+strconv.Itoa(int(c.ID))+`/delete" method="post" class="inline">
+							<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 							<button type="submit" class="text-red-600 hover:text-red-700" onclick="return confirm('Are you sure?')">Delete</button>
 						</form>
 					</td>

--- a/cmd/web/views/admin/caliber/new.templ
+++ b/cmd/web/views/admin/caliber/new.templ
@@ -37,6 +37,7 @@ templ New(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/calibers" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="caliber">
 						Caliber

--- a/cmd/web/views/admin/caliber/show.templ
+++ b/cmd/web/views/admin/caliber/show.templ
@@ -23,6 +23,7 @@ templ Show(data *data.AdminData) {
 						Edit
 					</a>
 					<form action="/admin/calibers/`+strconv.Itoa(int(data.Caliber.ID))+`/delete" method="post" class="inline">
+						<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 						<button type="submit" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded" onclick="return confirm('Are you sure?')">
 							Delete
 						</button>

--- a/cmd/web/views/admin/manufacturer/edit.templ
+++ b/cmd/web/views/admin/manufacturer/edit.templ
@@ -39,6 +39,7 @@ templ Edit(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/manufacturers/`+strconv.Itoa(int(data.Manufacturer.ID))+`" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="name">
 						Name

--- a/cmd/web/views/admin/manufacturer/index.templ
+++ b/cmd/web/views/admin/manufacturer/index.templ
@@ -108,6 +108,7 @@ templ Index(data *data.AdminData) {
 										<a href="/admin/manufacturers/`+strconv.Itoa(int(m.ID))+`" class="text-brass-600 hover:text-brass-700 font-medium mr-3">View</a>
 										<a href="/admin/manufacturers/`+strconv.Itoa(int(m.ID))+`/edit" class="text-brass-600 hover:text-brass-700 font-medium mr-3">Edit</a>
 										<form action="/admin/manufacturers/`+strconv.Itoa(int(m.ID))+`/delete" method="post" class="inline">
+											<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 											<button type="submit" class="text-red-600 hover:text-red-700 font-medium" onclick="return confirm('Are you sure?')">Delete</button>
 										</form>
 									</td>

--- a/cmd/web/views/admin/manufacturer/new.templ
+++ b/cmd/web/views/admin/manufacturer/new.templ
@@ -37,6 +37,7 @@ templ New(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/manufacturers" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="name">
 						Name

--- a/cmd/web/views/admin/manufacturer/show.templ
+++ b/cmd/web/views/admin/manufacturer/show.templ
@@ -23,6 +23,7 @@ templ Show(data *data.AdminData) {
 						Edit
 					</a>
 					<form action="/admin/manufacturers/`+strconv.Itoa(int(data.Manufacturer.ID))+`/delete" method="post" class="inline">
+						<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 						<button type="submit" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded" onclick="return confirm('Are you sure?')">
 							Delete
 						</button>

--- a/cmd/web/views/admin/stripe_security.templ
+++ b/cmd/web/views/admin/stripe_security.templ
@@ -154,6 +154,7 @@ templ StripeSecurityPage(data *StripeSecurityData) {
 							
 							<div class="mb-4">
 								<form method="post" action="/admin/stripe-security/toggle-filtering" class="mb-2">
+									<input type="hidden" name="csrf_token" value="` + data.CSRFToken + `">
 									<button type="submit" class="px-4 py-2 bg-gunmetal-700 hover:bg-gunmetal-800 text-white rounded font-medium transition">
 										`)
 		if err != nil {
@@ -174,6 +175,7 @@ templ StripeSecurityPage(data *StripeSecurityData) {
 								</form>
 								
 								<form method="post" action="/admin/stripe-security/refresh" class="mb-2">
+									<input type="hidden" name="csrf_token" value="` + data.CSRFToken + `">
 									<button type="submit" class="px-4 py-2 bg-brass-500 hover:bg-brass-600 text-white rounded font-medium transition">
 										Refresh IP Ranges
 									</button>

--- a/cmd/web/views/admin/stripe_test_ip.templ
+++ b/cmd/web/views/admin/stripe_test_ip.templ
@@ -42,6 +42,7 @@ templ IPTestPage(data *data.AuthData) {
 						</div>
 						<div class="p-6">
 							<form method="post" action="/admin/stripe-security/check-ip" class="space-y-4">
+								<input type="hidden" name="csrf_token" value="` + data.CSRFToken + `">
 								<div>
 									<label for="ip" class="block text-sm font-medium text-gray-700 mb-1">IP Address</label>
 									<input type="text" id="ip" name="ip" placeholder="Enter IP address to test (e.g. 3.18.12.63)" 

--- a/cmd/web/views/admin/weapon_type/edit.templ
+++ b/cmd/web/views/admin/weapon_type/edit.templ
@@ -39,6 +39,7 @@ templ Edit(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/weapon_types/`+strconv.Itoa(int(data.WeaponType.ID))+`" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="type">
 						Type

--- a/cmd/web/views/admin/weapon_type/index.templ
+++ b/cmd/web/views/admin/weapon_type/index.templ
@@ -96,6 +96,7 @@ templ Index(data *data.AdminData) {
 						<a href="/admin/weapon_types/`+strconv.Itoa(int(wt.ID))+`" class="text-blue-600 hover:text-blue-900 mr-3">View</a>
 						<a href="/admin/weapon_types/`+strconv.Itoa(int(wt.ID))+`/edit" class="text-amber-600 hover:text-amber-900 mr-3">Edit</a>
 						<form action="/admin/weapon_types/`+strconv.Itoa(int(wt.ID))+`/delete" method="post" class="inline">
+							<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 							<button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure?')">Delete</button>
 						</form>
 					</td>

--- a/cmd/web/views/admin/weapon_type/new.templ
+++ b/cmd/web/views/admin/weapon_type/new.templ
@@ -37,6 +37,7 @@ templ New(data *data.AdminData) {
 		_, err = io.WriteString(w, `
 		<div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
 			<form action="/admin/weapon_types" method="post">
+				<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 				<div class="mb-4">
 					<label class="block text-gray-700 text-sm font-bold mb-2" for="type">
 						Type

--- a/cmd/web/views/admin/weapon_type/show.templ
+++ b/cmd/web/views/admin/weapon_type/show.templ
@@ -23,6 +23,7 @@ templ Show(data *data.AdminData) {
 						Edit
 					</a>
 					<form action="/admin/weapon_types/`+strconv.Itoa(int(data.WeaponType.ID))+`/delete" method="post" class="inline">
+						<input type="hidden" name="csrf_token" value="` + data.AuthData.CSRFToken + `">
 						<button type="submit" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded" onclick="return confirm('Are you sure?')">
 							Delete
 						</button>

--- a/cmd/web/views/owner/gun/edit.templ
+++ b/cmd/web/views/owner/gun/edit.templ
@@ -92,6 +92,7 @@ templ Edit(data *data.OwnerData) {
 						type="date" 
 						id="acquired_date" 
 						name="acquired_date"
+						placeholder="MM-DD-YYYY"
 						value="`+ func() string {
 							if data.Gun.Acquired != nil {
 								return data.Gun.Acquired.Format("2006-01-02")
@@ -100,21 +101,7 @@ templ Edit(data *data.OwnerData) {
 						}() +`"
 						class="block w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-brass-500 focus:border-brass-500"
 					/>
-					`)
-		if err != nil {
-			return err
-		}
-
-		if acquiredDateError, ok := data.FormErrors["acquired_date"]; ok {
-			_, err = io.WriteString(w, `
-					<p class="text-red-500 text-xs italic">`+acquiredDateError+`</p>
-					`)
-			if err != nil {
-				return err
-			}
-		}
-
-		_, err = io.WriteString(w, `
+					<p class="text-gunmetal-500 text-xs">Format: MM-DD-YYYY</p>
 				</div>
 				<div class="mb-4">
 					<label for="paid" class="block text-gunmetal-700 font-medium mb-1">Paid (USD)</label>

--- a/cmd/web/views/owner/gun/new.templ
+++ b/cmd/web/views/owner/gun/new.templ
@@ -88,7 +88,8 @@ templ New(data *data.OwnerData) {
 						Acquired Date
 					</label>
 					<input class="shadow appearance-none border rounded w-full py-2 px-3 text-gunmetal-800 leading-tight focus:outline-none focus:shadow-outline" 
-						id="acquired" type="date" name="acquired">
+						id="acquired" type="date" name="acquired" placeholder="MM-DD-YYYY">
+					<p class="text-gunmetal-500 text-xs">Format: MM-DD-YYYY</p>
 					`)
 		if err != nil {
 			return err

--- a/internal/controller/owner.go
+++ b/internal/controller/owner.go
@@ -491,7 +491,7 @@ func (o *OwnerController) Create(c *gin.Context) {
 	if acquiredDateStr != "" {
 		parsedDate, err := time.Parse("2006-01-02", acquiredDateStr)
 		if err != nil {
-			errors["acquired"] = "Invalid date format, use YYYY-MM-DD"
+			errors["acquired"] = "Invalid date format, use MM-DD-YYYY"
 		} else {
 			// Check if date is in the future
 			if parsedDate.After(time.Now()) {
@@ -1160,7 +1160,7 @@ func (o *OwnerController) Update(c *gin.Context) {
 		if acquiredDateStr != "" {
 			parsedDate, err := time.Parse("2006-01-02", acquiredDateStr)
 			if err != nil {
-				formErrors["acquired_date"] = "Invalid date format, use YYYY-MM-DD"
+				formErrors["acquired_date"] = "Invalid date format, use MM-DD-YYYY"
 			} else {
 				// Check if date is in the future
 				if parsedDate.After(time.Now()) {
@@ -1421,7 +1421,7 @@ func (o *OwnerController) Update(c *gin.Context) {
 	if acquiredDateStr != "" {
 		parsedDate, err := time.Parse("2006-01-02", acquiredDateStr)
 		if err != nil {
-			formErrors["acquired_date"] = "Invalid date format, use YYYY-MM-DD"
+			formErrors["acquired_date"] = "Invalid date format, use MM-DD-YYYY"
 		} else {
 			// Check if date is in the future
 			if parsedDate.After(time.Now()) {

--- a/internal/database/seed/seed.go
+++ b/internal/database/seed/seed.go
@@ -3,11 +3,18 @@ package seed
 import (
 	"log"
 
+	"github.com/hail2skins/armory/internal/models"
 	"gorm.io/gorm"
 )
 
 // RunSeeds executes all seed functions
 func RunSeeds(db *gorm.DB) {
+	// Check if database already contains data
+	if !NeedsSeeding(db) {
+		log.Println("Database already contains data, skipping seed")
+		return
+	}
+
 	log.Println("Starting database seeding...")
 
 	// Run manufacturer seeds
@@ -25,4 +32,41 @@ func RunSeeds(db *gorm.DB) {
 	// Add more seed functions here as needed
 
 	log.Println("Database seeding completed")
+}
+
+// NeedsSeeding checks if the database needs to be seeded by checking
+// if any essential reference data already exists
+func NeedsSeeding(db *gorm.DB) bool {
+	// Check weapon types (if any exist, we'll assume the database has been seeded)
+	var weaponTypeCount int64
+	if err := db.Model(&models.WeaponType{}).Count(&weaponTypeCount).Error; err != nil {
+		log.Printf("Error checking weapon types: %v", err)
+		return true // If there's an error, assume we need to seed
+	}
+	if weaponTypeCount > 0 {
+		return false
+	}
+
+	// Check calibers
+	var caliberCount int64
+	if err := db.Model(&models.Caliber{}).Count(&caliberCount).Error; err != nil {
+		log.Printf("Error checking calibers: %v", err)
+		return true
+	}
+	if caliberCount > 0 {
+		return false
+	}
+
+	// Check manufacturers
+	var manufacturerCount int64
+	if err := db.Model(&models.Manufacturer{}).Count(&manufacturerCount).Error; err != nil {
+		log.Printf("Error checking manufacturers: %v", err)
+		return true
+	}
+	if manufacturerCount > 0 {
+		return false
+	}
+
+	// If we reach here, no data exists, so we need to seed
+	return true
 }

--- a/internal/database/seed/seed_test.go
+++ b/internal/database/seed/seed_test.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/hail2skins/armory/internal/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
 func TestSeedManufacturers(t *testing.T) {
 	// Setup in-memory database for testing
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
 	assert.NoError(t, err)
 
 	// Auto migrate the schema
@@ -36,7 +37,7 @@ func TestSeedManufacturers(t *testing.T) {
 
 func TestSeedCalibers(t *testing.T) {
 	// Setup in-memory database for testing
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
 	assert.NoError(t, err)
 
 	// Auto migrate the schema
@@ -60,7 +61,7 @@ func TestSeedCalibers(t *testing.T) {
 
 func TestSeedWeaponTypes(t *testing.T) {
 	// Setup in-memory database for testing
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
 	assert.NoError(t, err)
 
 	// Auto migrate the schema
@@ -84,7 +85,7 @@ func TestSeedWeaponTypes(t *testing.T) {
 
 func TestRunSeeds(t *testing.T) {
 	// Setup in-memory database for testing
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
 	assert.NoError(t, err)
 
 	// Auto migrate the schema
@@ -105,4 +106,82 @@ func TestRunSeeds(t *testing.T) {
 
 	db.Model(&models.WeaponType{}).Count(&weaponTypeCount)
 	assert.Greater(t, weaponTypeCount, int64(0), "No weapon types were seeded")
+}
+
+// Add a new test for the NeedsSeeding function and seed once strategy
+func TestNeedsSeeding(t *testing.T) {
+	// Create a separate database for this test
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	require.NoError(t, err, "Failed to create in-memory database")
+
+	// Run migrations to create tables
+	err = db.AutoMigrate(&models.WeaponType{}, &models.Caliber{}, &models.Manufacturer{})
+	require.NoError(t, err, "Failed to run migrations")
+
+	// Test 1: Empty database should need seeding
+	assert.True(t, NeedsSeeding(db), "Empty database should need seeding")
+
+	// Test 2: Add one weapon type and check that it no longer needs seeding
+	weaponType := models.WeaponType{Type: "Test Type", Nickname: "Test", Popularity: 1}
+	err = db.Create(&weaponType).Error
+	require.NoError(t, err, "Failed to create test weapon type")
+
+	assert.False(t, NeedsSeeding(db), "Database with data should not need seeding")
+
+	// Test 3: Clear the database and verify it needs seeding again
+	db.Exec("DELETE FROM weapon_types")
+	db.Exec("DELETE FROM calibers")
+	db.Exec("DELETE FROM manufacturers")
+
+	assert.True(t, NeedsSeeding(db), "Empty database should need seeding again")
+
+	// Test 4: Test the seed once behavior by adding only a caliber
+	caliber := models.Caliber{Caliber: "Test Caliber", Nickname: "Test", Popularity: 1}
+	err = db.Create(&caliber).Error
+	require.NoError(t, err, "Failed to create test caliber")
+
+	assert.False(t, NeedsSeeding(db), "Database with only calibers should not need seeding")
+}
+
+// Test RunSeeds with the new seed once behavior
+func TestRunSeedsOnce(t *testing.T) {
+	// Create a separate database for this test
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	require.NoError(t, err, "Failed to create in-memory database")
+
+	// Run migrations to create tables
+	err = db.AutoMigrate(&models.WeaponType{}, &models.Caliber{}, &models.Manufacturer{})
+	require.NoError(t, err, "Failed to run migrations")
+
+	// Run seeds for the first time
+	RunSeeds(db)
+
+	// Count entities to verify data was seeded
+	var weaponTypeCount, caliberCount, manufacturerCount int64
+	db.Model(&models.WeaponType{}).Count(&weaponTypeCount)
+	db.Model(&models.Caliber{}).Count(&caliberCount)
+	db.Model(&models.Manufacturer{}).Count(&manufacturerCount)
+
+	assert.Greater(t, weaponTypeCount, int64(0), "Weapon types should be seeded")
+	assert.Greater(t, caliberCount, int64(0), "Calibers should be seeded")
+	assert.Greater(t, manufacturerCount, int64(0), "Manufacturers should be seeded")
+
+	// Remember the counts
+	initialCounts := map[string]int64{
+		"weaponTypes":   weaponTypeCount,
+		"calibers":      caliberCount,
+		"manufacturers": manufacturerCount,
+	}
+
+	// Run seeds again
+	RunSeeds(db)
+
+	// Verify counts have not changed
+	db.Model(&models.WeaponType{}).Count(&weaponTypeCount)
+	db.Model(&models.Caliber{}).Count(&caliberCount)
+	db.Model(&models.Manufacturer{}).Count(&manufacturerCount)
+
+	assert.Equal(t, initialCounts["weaponTypes"], weaponTypeCount, "Weapon type count should not change on second seed")
+	assert.Equal(t, initialCounts["calibers"], caliberCount, "Caliber count should not change on second seed")
+	assert.Equal(t, initialCounts["manufacturers"], manufacturerCount, "Manufacturer count should not change on second seed")
 }

--- a/tests/admin_caliber_csrf_test.go
+++ b/tests/admin_caliber_csrf_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hail2skins/armory/internal/controller"
+	"github.com/hail2skins/armory/internal/models"
+	"github.com/hail2skins/armory/internal/testutils/mocks"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+// AdminCaliberCSRFSuite is a test suite for verifying CSRF tokens in caliber templates
+type AdminCaliberCSRFSuite struct {
+	suite.Suite
+	Router      *gin.Engine
+	MockDB      *mocks.MockDB
+	Controller  *controller.AdminCaliberController
+	Recorder    *httptest.ResponseRecorder
+	TestCaliber *models.Caliber
+}
+
+// SetupTest is called before each test
+func (s *AdminCaliberCSRFSuite) SetupTest() {
+	gin.SetMode(gin.TestMode)
+	s.Router = gin.Default()
+	s.MockDB = &mocks.MockDB{}
+	s.Controller = controller.NewAdminCaliberController(s.MockDB)
+	s.Recorder = httptest.NewRecorder()
+
+	// Create a test caliber for use in tests
+	s.TestCaliber = &models.Caliber{
+		Model:      gorm.Model{ID: 1},
+		Caliber:    "Test Caliber",
+		Nickname:   "Test",
+		Popularity: 50,
+	}
+
+	// Setup mock authentication middleware with CSRF token
+	s.Router.Use(func(c *gin.Context) {
+		c.Set("authData", map[string]interface{}{
+			"Authenticated": true,
+			"Email":         "admin@example.com",
+			"Roles":         []string{"admin"},
+			"IsCasbinAdmin": true,
+			"CSRFToken":     "mX0OwCuPLFmTs4Og0tANOmccR6NpB6OsM1XfoDa3VWQ=",
+		})
+		c.Next()
+	})
+
+	// Add test routes
+	s.Router.GET("/admin/calibers/new", s.Controller.New)
+	s.Router.GET("/admin/calibers/:id/edit", s.Controller.Edit)
+	s.Router.GET("/admin/calibers/:id", s.Controller.Show)
+	s.Router.GET("/admin/calibers", s.Controller.Index)
+}
+
+// TestAdminCaliberCSRFSuite runs the test suite
+func TestAdminCaliberCSRFSuite(t *testing.T) {
+	suite.Run(t, new(AdminCaliberCSRFSuite))
+}
+
+// TestNewFormCSRFToken tests that the new caliber form includes a CSRF token
+func (s *AdminCaliberCSRFSuite) TestNewFormCSRFToken() {
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/calibers/new", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "New Caliber")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestEditFormCSRFToken tests that the edit caliber form includes a CSRF token
+func (s *AdminCaliberCSRFSuite) TestEditFormCSRFToken() {
+	// Mock the FindCaliberByID method
+	s.MockDB.On("FindCaliberByID", uint(1)).Return(s.TestCaliber, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/calibers/1/edit", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Edit Caliber")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestShowCSRFToken tests that the delete form on the show page includes a CSRF token
+func (s *AdminCaliberCSRFSuite) TestShowCSRFToken() {
+	// Mock the FindCaliberByID method
+	s.MockDB.On("FindCaliberByID", uint(1)).Return(s.TestCaliber, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/calibers/1", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Caliber Details")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/calibers/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestIndexCSRFToken tests that the delete forms on the index page include CSRF tokens
+func (s *AdminCaliberCSRFSuite) TestIndexCSRFToken() {
+	// Mock the FindAllCalibers method
+	s.MockDB.On("FindAllCalibers").Return([]models.Caliber{*s.TestCaliber}, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/calibers", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Calibers")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/calibers/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}

--- a/tests/admin_manufacturer_csrf_test.go
+++ b/tests/admin_manufacturer_csrf_test.go
@@ -1,0 +1,132 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hail2skins/armory/internal/controller"
+	"github.com/hail2skins/armory/internal/models"
+	"github.com/hail2skins/armory/internal/testutils/mocks"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+// AdminManufacturerCSRFSuite is a test suite for verifying CSRF tokens in manufacturer templates
+type AdminManufacturerCSRFSuite struct {
+	suite.Suite
+	Router           *gin.Engine
+	MockDB           *mocks.MockDB
+	Controller       *controller.AdminManufacturerController
+	Recorder         *httptest.ResponseRecorder
+	TestManufacturer *models.Manufacturer
+}
+
+// SetupTest is called before each test
+func (s *AdminManufacturerCSRFSuite) SetupTest() {
+	gin.SetMode(gin.TestMode)
+	s.Router = gin.Default()
+	s.MockDB = &mocks.MockDB{}
+	s.Controller = controller.NewAdminManufacturerController(s.MockDB)
+	s.Recorder = httptest.NewRecorder()
+
+	// Create a test manufacturer for use in tests
+	s.TestManufacturer = &models.Manufacturer{
+		Model:      gorm.Model{ID: 1},
+		Name:       "Test Manufacturer",
+		Nickname:   "Test",
+		Country:    "Test Country",
+		Popularity: 50,
+	}
+
+	// Setup mock authentication middleware with CSRF token
+	s.Router.Use(func(c *gin.Context) {
+		c.Set("authData", map[string]interface{}{
+			"Authenticated": true,
+			"Email":         "admin@example.com",
+			"Roles":         []string{"admin"},
+			"IsCasbinAdmin": true,
+			"CSRFToken":     "mX0OwCuPLFmTs4Og0tANOmccR6NpB6OsM1XfoDa3VWQ=",
+		})
+		c.Next()
+	})
+
+	// Add test routes
+	s.Router.GET("/admin/manufacturers/new", s.Controller.New)
+	s.Router.GET("/admin/manufacturers/:id/edit", s.Controller.Edit)
+	s.Router.GET("/admin/manufacturers/:id", s.Controller.Show)
+	s.Router.GET("/admin/manufacturers", s.Controller.Index)
+}
+
+// TestAdminManufacturerCSRFSuite runs the test suite
+func TestAdminManufacturerCSRFSuite(t *testing.T) {
+	suite.Run(t, new(AdminManufacturerCSRFSuite))
+}
+
+// TestNewFormCSRFToken tests that the new manufacturer form includes a CSRF token
+func (s *AdminManufacturerCSRFSuite) TestNewFormCSRFToken() {
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/manufacturers/new", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "New Manufacturer")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestEditFormCSRFToken tests that the edit manufacturer form includes a CSRF token
+func (s *AdminManufacturerCSRFSuite) TestEditFormCSRFToken() {
+	// Mock the FindManufacturerByID method
+	s.MockDB.On("FindManufacturerByID", uint(1)).Return(s.TestManufacturer, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/manufacturers/1/edit", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Edit Manufacturer")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestShowCSRFToken tests that the delete form on the show page includes a CSRF token
+func (s *AdminManufacturerCSRFSuite) TestShowCSRFToken() {
+	// Mock the FindManufacturerByID method
+	s.MockDB.On("FindManufacturerByID", uint(1)).Return(s.TestManufacturer, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/manufacturers/1", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Manufacturer Details")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/manufacturers/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestIndexCSRFToken tests that the delete forms on the index page include CSRF tokens
+func (s *AdminManufacturerCSRFSuite) TestIndexCSRFToken() {
+	// Mock the FindAllManufacturers method
+	s.MockDB.On("FindAllManufacturers").Return([]models.Manufacturer{*s.TestManufacturer}, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/manufacturers", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Manufacturers")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/manufacturers/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}

--- a/tests/admin_stripe_security_csrf_test.go
+++ b/tests/admin_stripe_security_csrf_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStripeSecurityCSRFTokens checks the Stripe security template files for CSRF token input fields
+func TestStripeSecurityCSRFTokens(t *testing.T) {
+	// Use absolute paths to the template files
+	securityTemplPath := "/home/art/armory/cmd/web/views/admin/stripe_security.templ"
+	testIPTemplPath := "/home/art/armory/cmd/web/views/admin/stripe_test_ip.templ"
+
+	// Read the security template file
+	securityTempl, err := os.ReadFile(securityTemplPath)
+	if err != nil {
+		t.Skipf("Skipping test: could not read security template file: %v", err)
+	}
+
+	// Read the IP test template file
+	testIPTempl, err := os.ReadFile(testIPTemplPath)
+	if err != nil {
+		t.Skipf("Skipping test: could not read IP test template file: %v", err)
+	}
+
+	// Convert files to string
+	securityTemplStr := string(securityTempl)
+	testIPTemplStr := string(testIPTempl)
+
+	// Test for CSRF token in toggle filtering form
+	assert.Contains(t, securityTemplStr,
+		`<form method="post" action="/admin/stripe-security/toggle-filtering"`,
+		"Security template should contain toggle filtering form")
+	assert.Contains(t, securityTemplStr,
+		`<input type="hidden" name="csrf_token" value="`+"`",
+		"Toggle filtering form should contain CSRF token")
+
+	// Test for CSRF token in refresh form
+	assert.Contains(t, securityTemplStr,
+		`<form method="post" action="/admin/stripe-security/refresh"`,
+		"Security template should contain refresh form")
+	assert.Contains(t, securityTemplStr,
+		`<input type="hidden" name="csrf_token" value="`+"`",
+		"Refresh form should contain CSRF token")
+
+	// Test for CSRF token in IP test form
+	assert.Contains(t, testIPTemplStr,
+		`<form method="post" action="/admin/stripe-security/check-ip"`,
+		"IP test template should contain check IP form")
+	assert.Contains(t, testIPTemplStr,
+		`<input type="hidden" name="csrf_token" value="`+"`",
+		"IP test form should contain CSRF token")
+}

--- a/tests/admin_weapon_type_csrf_test.go
+++ b/tests/admin_weapon_type_csrf_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hail2skins/armory/internal/controller"
+	"github.com/hail2skins/armory/internal/models"
+	"github.com/hail2skins/armory/internal/testutils/mocks"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+// AdminWeaponTypeCSRFSuite is a test suite for verifying CSRF tokens in weapon type templates
+type AdminWeaponTypeCSRFSuite struct {
+	suite.Suite
+	Router         *gin.Engine
+	MockDB         *mocks.MockDB
+	Controller     *controller.AdminWeaponTypeController
+	Recorder       *httptest.ResponseRecorder
+	TestWeaponType *models.WeaponType
+}
+
+// SetupTest is called before each test
+func (s *AdminWeaponTypeCSRFSuite) SetupTest() {
+	gin.SetMode(gin.TestMode)
+	s.Router = gin.Default()
+	s.MockDB = &mocks.MockDB{}
+	s.Controller = controller.NewAdminWeaponTypeController(s.MockDB)
+	s.Recorder = httptest.NewRecorder()
+
+	// Create a test weapon type for use in tests
+	s.TestWeaponType = &models.WeaponType{
+		Model:      gorm.Model{ID: 1},
+		Type:       "Test Type",
+		Nickname:   "Test",
+		Popularity: 50,
+	}
+
+	// Setup mock authentication middleware with CSRF token
+	s.Router.Use(func(c *gin.Context) {
+		c.Set("authData", map[string]interface{}{
+			"Authenticated": true,
+			"Email":         "admin@example.com",
+			"Roles":         []string{"admin"},
+			"IsCasbinAdmin": true,
+			"CSRFToken":     "mX0OwCuPLFmTs4Og0tANOmccR6NpB6OsM1XfoDa3VWQ=",
+		})
+		c.Next()
+	})
+
+	// Add test routes
+	s.Router.GET("/admin/weapon_types/new", s.Controller.New)
+	s.Router.GET("/admin/weapon_types/:id/edit", s.Controller.Edit)
+	s.Router.GET("/admin/weapon_types/:id", s.Controller.Show)
+	s.Router.GET("/admin/weapon_types", s.Controller.Index)
+}
+
+// TestAdminWeaponTypeCSRFSuite runs the test suite
+func TestAdminWeaponTypeCSRFSuite(t *testing.T) {
+	suite.Run(t, new(AdminWeaponTypeCSRFSuite))
+}
+
+// TestNewFormCSRFToken tests that the new weapon type form includes a CSRF token
+func (s *AdminWeaponTypeCSRFSuite) TestNewFormCSRFToken() {
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/weapon_types/new", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "New Weapon Type")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestEditFormCSRFToken tests that the edit weapon type form includes a CSRF token
+func (s *AdminWeaponTypeCSRFSuite) TestEditFormCSRFToken() {
+	// Mock the FindWeaponTypeByID method
+	s.MockDB.On("FindWeaponTypeByID", uint(1)).Return(s.TestWeaponType, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/weapon_types/1/edit", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Edit Weapon Type")
+
+	// Check for CSRF token in form
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestShowCSRFToken tests that the delete form on the show page includes a CSRF token
+func (s *AdminWeaponTypeCSRFSuite) TestShowCSRFToken() {
+	// Mock the FindWeaponTypeByID method
+	s.MockDB.On("FindWeaponTypeByID", uint(1)).Return(s.TestWeaponType, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/weapon_types/1", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Weapon Type Details")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/weapon_types/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}
+
+// TestIndexCSRFToken tests that the delete forms on the index page include CSRF tokens
+func (s *AdminWeaponTypeCSRFSuite) TestIndexCSRFToken() {
+	// Mock the FindAllWeaponTypes method
+	s.MockDB.On("FindAllWeaponTypes").Return([]models.WeaponType{*s.TestWeaponType}, nil)
+
+	// Send request
+	req, _ := http.NewRequest("GET", "/admin/weapon_types", nil)
+	s.Router.ServeHTTP(s.Recorder, req)
+
+	// Assert response
+	s.Equal(http.StatusOK, s.Recorder.Code)
+	s.Contains(s.Recorder.Body.String(), "Weapon Types")
+
+	// Check for CSRF token in delete form
+	s.Contains(s.Recorder.Body.String(), `<form action="/admin/weapon_types/1/delete" method="post"`)
+	s.Contains(s.Recorder.Body.String(), `<input type="hidden" name="csrf_token" value=`)
+}


### PR DESCRIPTION
Implemented CSRF protection for all admin templates including manufacturer, caliber, weapon type, and stripe security forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Overhauled the project overview with detailed descriptions of features, technology stack, setup instructions, and workflow.
  - Introduced new guidelines outlining project rules and build/run instructions.

- **New Features**
  - Enhanced form security by integrating CSRF token protection into administrative interfaces.
  - Updated gun entry forms with clear "MM-DD-YYYY" date format instructions and improved error messaging.

- **Tests**
  - Expanded test coverage to ensure new security measures and one-time data setup work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->